### PR TITLE
[GAE Std J8 getting started] - Datastore sample

### DIFF
--- a/datastore/README.md
+++ b/datastore/README.md
@@ -1,0 +1,24 @@
+# Google App Engine Standard Environment Datastore Sample
+
+This sample demonstrates how to deploy an App Engine Java 8 application that
+uses Cloud Datastore for storage.
+
+See the [Google App Engine standard environment documentation][ae-docs] for more
+detailed instructions.
+
+[ae-docs]: https://cloud.google.com/appengine/docs/java/
+
+## Setup
+
+1.  Update the `<application>` tag in
+    `src/main/webapp/WEB-INF/appengine-web.xml` with your project name.
+1.  Update the `<version>` tag in `src/main/webapp/WEB-INF/appengine-web.xml`
+    with your version name.
+
+## Running locally
+
+    $ mvn appengine:devserver
+
+## Deploying
+
+    $ mvn appengine:update

--- a/datastore/pom.xml
+++ b/datastore/pom.xml
@@ -1,0 +1,118 @@
+<!--
+Copyright 2017 Google Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<!-- [START pom] -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>war</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <groupId>com.example.appengine</groupId>
+  <artifactId>appengine-datastore</artifactId>
+
+  <properties>
+      <appengine.sdk.version>1.9.54</appengine.sdk.version>
+      <appengine.app.version>1</appengine.app.version>
+
+      <project.http.version>1.19.0</project.http.version>
+      <project.oauth.version>1.19.0</project.oauth.version>
+
+      <maven.compiler.target>1.8</maven.compiler.target>
+      <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <type>jar</type>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.54</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client-appengine</artifactId>
+      <version>1.22.0</version>
+    </dependency>
+    <dependency>
+      <groupId>jstl</groupId>
+      <artifactId>jstl</artifactId>
+      <version>1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <version>1.10.3</version>
+    </dependency>
+
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-testing</artifactId>
+      <version>${appengine.sdk.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-stubs</artifactId>
+      <version>${appengine.sdk.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-tools-sdk</artifactId>
+      <version>${appengine.sdk.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>0.36</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <!-- for hot reload of the web application -->
+    <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes</outputDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <version>3.3</version>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <!-- Parent POM defines ${appengine.sdk.version} (updates frequently). -->
+      <plugin>
+        <groupId>com.google.appengine</groupId>
+        <artifactId>appengine-maven-plugin</artifactId>
+        <version>${appengine.sdk.version}</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+<!-- [END pom] -->

--- a/datastore/src/main/java/com/example/appengine/datastore/DeleteEntities.java
+++ b/datastore/src/main/java/com/example/appengine/datastore/DeleteEntities.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.appengine.datastore;
+
+import com.google.appengine.api.datastore.DatastoreFailureException;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.KeyFactory;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Whitelist;
+
+@SuppressWarnings("serial")
+@WebServlet(name = "DeleteEntities", description = "Delete a blog post", value = "/delete")
+public class DeleteEntities extends HttpServlet {
+
+  DatastoreService datastore;
+
+  @Override
+  public void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+
+    PrintWriter out = resp.getWriter();
+
+    // Create a map of the httpParameters, filter to only have the ID and run it through jSoup
+    Map<String, String> blogContent =
+        req.getParameterMap()
+            .entrySet()
+            .stream()
+            .filter(a -> a.getKey().startsWith("id"))
+            .collect(
+                Collectors.toMap(
+                    p -> p.getKey(), p -> Jsoup.clean(p.getValue()[0], Whitelist.basic())));
+
+    try {
+      datastore.delete(KeyFactory.createKey("Blogpost", Long.parseLong(blogContent.get("id"))));
+
+      // Send the user to the confirmation page with personalised confirmation text
+      String confirmation = "Post " + blogContent.get("id") + " has been deleted.";
+
+      req.setAttribute("confirmation", confirmation);
+      req.getRequestDispatcher("/confirm.jsp").forward(req, resp);
+
+    } catch (DatastoreFailureException e) {
+      throw new ServletException("Datastore error", e);
+    }
+  }
+
+  @Override
+  public void init() throws ServletException {
+
+    // setup datastore service
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+}

--- a/datastore/src/main/java/com/example/appengine/datastore/ListEntities.java
+++ b/datastore/src/main/java/com/example/appengine/datastore/ListEntities.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.appengine.datastore;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@SuppressWarnings("serial")
+@WebServlet(name = "ListEntities", description = "List the latest news posts", urlPatterns = "/")
+public class ListEntities extends HttpServlet {
+
+  DatastoreService datastore;
+
+  final Query q =
+      new Query("Blogpost").setFilter(new FilterPredicate("title", FilterOperator.NOT_EQUAL, ""));
+
+  @Override
+  public void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+
+    PreparedQuery pq = datastore.prepare(q);
+    List<Entity> posts = pq.asList(FetchOptions.Builder.withLimit(5));
+
+    PrintWriter out = resp.getWriter();
+
+    out.println(
+        "<h1>Welcome to the App Engine Blog</h1><h3><a href=\"form.jsp\">Add a new post</a></h3>");
+
+    posts.forEach(
+        (result) -> {
+          out.println(
+              "<h2>"
+                  + result.getProperty("title")
+                  + "</h2> Posted at: "
+                  + result.getProperty("timestamp")
+                  + " by "
+                  + result.getProperty("author")
+                  + " [<a href=\"/update?id="
+                  + result.getKey().getId()
+                  + "\">update</a>] | "
+                  + "[<a href=\"/delete?id="
+                  + result.getKey().getId()
+                  + "\">delete</a>]<br><br>"
+                  + result.getProperty("body")
+                  + "<br><br>");
+        });
+  }
+
+  @Override
+  public void init() throws ServletException {
+
+    // Setup datastore connection
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+}

--- a/datastore/src/main/java/com/example/appengine/datastore/UpdateEntities.java
+++ b/datastore/src/main/java/com/example/appengine/datastore/UpdateEntities.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.appengine.datastore;
+
+import com.google.appengine.api.datastore.DatastoreFailureException;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.appengine.api.datastore.KeyFactory;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Date;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Whitelist;
+
+@SuppressWarnings("serial")
+@WebServlet(name = "UpdateEntities", description = "Update a post", urlPatterns = "/update")
+public class UpdateEntities extends HttpServlet {
+
+  DatastoreService datastore;
+
+  @Override
+  public void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+
+    Long postId = Long.parseLong(req.getParameter("id"));
+    PrintWriter out = resp.getWriter();
+
+    datastore = DatastoreServiceFactory.getDatastoreService();
+
+    try {
+      Entity post = datastore.get(KeyFactory.createKey("Blogpost", postId));
+
+      out.println(
+          "<!doctype html public \"-//w3c//dtd html 4.0 "
+              + "transitional//en\">\n"
+              + "<html>\n"
+              + "<head><title>Updating a post</title></head><body>\n"
+              + "<h2>Update Post</h2>"
+              + "<form method=\"POST\" action=\"/update\">"
+              + "<div>"
+              + "<label for=\"title\">Title</label>"
+              + "<input type=\"text\" name=\"blogContent_title\" id=\"blogContent_title\" size=\"40\" value=\""
+              + post.getProperty("title")
+              + "\" class=\"form-control\" />"
+              + "</div>"
+              + "<div>"
+              + "<label for=\"description\">Post content</label>"
+              + "<textarea name=\"blogContent_body\" id=\"blogContent_body\" rows=\"10\" cols=\"50\" class=\"form-control\">"
+              + post.getProperty("body")
+              + "</textarea>"
+              + "</div>"
+              + "<button type=\"submit\">Save</button>"
+              + "<input type=\"hidden\" id=\"blogContent_id\" name=\"blogContent_id\" value=\""
+              + postId
+              + "\">"
+              + "<input type=\"hidden\" id=\"blogContent_author\" name=\"blogContent_author\" value=\""
+              + post.getProperty("author")
+              + "\">"
+              + "</form>"
+              + "</body></html>");
+
+    } catch (EntityNotFoundException e) {
+      throw new ServletException("Datastore error", e);
+    }
+  }
+
+  @Override
+  public void doPost(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+
+    // Create a map of the httpParameters that we want and run it through jSoup
+    Map<String, String> blogContent =
+        req.getParameterMap()
+            .entrySet()
+            .stream()
+            .filter(a -> a.getKey().startsWith("blogContent_"))
+            .collect(
+                Collectors.toMap(
+                    p -> p.getKey(), p -> Jsoup.clean(p.getValue()[0], Whitelist.basic())));
+
+    // Create the entity with the same key in order to overwrite it
+    Entity post = new Entity("Blogpost", Long.parseLong(blogContent.get("blogContent_id")));
+
+    post.setProperty("title", blogContent.get("blogContent_title"));
+    post.setProperty("author", blogContent.get("blogContent_author"));
+    post.setProperty("body", blogContent.get("blogContent_body"));
+    post.setProperty("timestamp", new Date());
+
+    try {
+      datastore.put(post); // store the post
+
+      // Send the user to the confirmation page with personalised confirmation text
+      String confirmation = "Post with title " + blogContent.get("blogContent_title") + " updated.";
+
+      req.setAttribute("confirmation", confirmation);
+      req.getRequestDispatcher("/confirm.jsp").forward(req, resp);
+    } catch (DatastoreFailureException e) {
+      throw new ServletException("Datastore error", e);
+    }
+  }
+
+  @Override
+  public void init() throws ServletException {
+
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+}

--- a/datastore/src/main/java/com/example/appengine/datastore/WriteEntities.java
+++ b/datastore/src/main/java/com/example/appengine/datastore/WriteEntities.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.appengine.datastore;
+
+import com.google.appengine.api.datastore.DatastoreFailureException;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import java.io.IOException;
+import java.util.Date;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Whitelist;
+
+@SuppressWarnings("serial")
+@WebServlet(
+  name = "WriteEntities",
+  description = "Create a Datastore entity",
+  urlPatterns = "/create"
+)
+public class WriteEntities extends HttpServlet {
+
+  DatastoreService datastore;
+
+  @Override
+  public void doPost(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+
+    // Create a map of the httpParameters that we want and run it through jSoup
+    Map<String, String> blogContent =
+        req.getParameterMap()
+            .entrySet()
+            .stream()
+            .filter(a -> a.getKey().startsWith("blogContent_"))
+            .collect(
+                Collectors.toMap(
+                    p -> p.getKey(), p -> Jsoup.clean(p.getValue()[0], Whitelist.basic())));
+
+    Entity post = new Entity("Blogpost"); // create a new entity
+
+    post.setProperty("title", blogContent.get("blogContent_title"));
+    post.setProperty("author", blogContent.get("blogContent_author"));
+    post.setProperty("body", blogContent.get("blogContent_description"));
+    post.setProperty("timestamp", new Date());
+
+    try {
+      datastore.put(post); // store the entity
+
+      // Send the user to the confirmation page with personalised confirmation text
+      String confirmation = "Post with title " + blogContent.get("blogContent_title") + " created.";
+
+      req.setAttribute("confirmation", confirmation);
+      req.getRequestDispatcher("/confirm.jsp").forward(req, resp);
+    } catch (DatastoreFailureException e) {
+      throw new ServletException("Datastore error", e);
+    }
+  }
+
+  @Override
+  public void init() throws ServletException {
+
+    // setup datastore service
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+}

--- a/datastore/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/datastore/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2017 Google Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- [START config] -->
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+  <application>YOUR-APP-NAME</application>
+  <version>1</version>
+  <threadsafe>true</threadsafe>
+  <runtime>java8</runtime>
+  <use-google-connector-j>true</use-google-connector-j>
+
+  <static-files>
+    <include path="/**.html" >
+    </include>
+  </static-files>
+</appengine-web-app>
+<!-- [END config] -->

--- a/datastore/src/main/webapp/WEB-INF/web.xml
+++ b/datastore/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+         http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>blog</web-resource-name>
+      <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <user-data-constraint>
+      <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+    </user-data-constraint>
+  </security-constraint>
+</web-app>

--- a/datastore/src/main/webapp/confirm.jsp
+++ b/datastore/src/main/webapp/confirm.jsp
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Database confirmation</title>
+    </head>
+    <body>
+         <p>${confirmation}</p>
+    </body>
+</html>

--- a/datastore/src/main/webapp/form.jsp
+++ b/datastore/src/main/webapp/form.jsp
@@ -1,0 +1,35 @@
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn"%>
+<div>
+   <c:choose>
+    <c:when test="${id == null}">
+      <h2>Create a new blog post</h2>
+      <form method="POST" action="/create">
+    </c:when>
+    <c:otherwise>
+      <h2><c:out value="${pagetitle}" /></h2>
+      <form method="POST" action="/update">
+      <input type="hidden" name="blogContent_id" value="${id}">
+    </c:otherwise>
+  </c:choose>
+
+  <form method="POST" action="/create">
+
+    <div>
+      <label for="title">Title</label>
+      <input type="text" name="blogContent_title" id="title" size="40" value=""/>
+    </div>
+
+    <div>
+      <label for="author">Author</label>
+      <input type="text" name="blogContent_author" id="author" size="40" value=""/>
+    </div>
+
+    <div>
+      <label for="description">Post content</label>
+      <textarea name="blogContent_description" id="description" rows="10" cols="50"></textarea>
+    </div>
+
+    <button type="submit">Save</button>
+  </form>
+</div>

--- a/datastore/src/test/java/com/example/appengine/DeleteEntitiesTest.java
+++ b/datastore/src/test/java/com/example/appengine/DeleteEntitiesTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine.datatstore;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link DeleteEntities}. */
+@RunWith(JUnit4.class)
+public final class DeleteEntitiesTest {
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          // Set no eventual consistency, that way queries return all results.
+          // https://cloud.google.com/appengine/docs/java/tools/localunittesting#Java_Writing_High_Replication_Datastore_tests
+          new LocalDatastoreServiceTestConfig()
+              .setDefaultHighRepJobPolicyUnappliedJobPercentage(0));
+
+  private DatastoreService datastore;
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void entityDelete() throws Exception {
+
+    // Create and store an entity for deletion
+    Entity newsPost = new Entity("Blogpost", "breakingnews");
+    datastore.put(newsPost);
+
+    Key newsPostKey = KeyFactory.createKey("Blogpost", "breakingnews");
+    datastore.delete(newsPostKey);
+
+    try {
+      Entity got = datastore.get(newsPostKey);
+      fail("Expected EntityNotFoundException");
+    } catch (EntityNotFoundException expected) {
+      assertThat(expected.getKey().getName()).named("exception key name").isEqualTo("breakingnews");
+    }
+  }
+}

--- a/datastore/src/test/java/com/example/appengine/ListEntitiesTest.java
+++ b/datastore/src/test/java/com/example/appengine/ListEntitiesTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine.datatstore;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.common.collect.ImmutableList;
+import java.util.Date;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link ListEntities}. */
+@RunWith(JUnit4.class)
+public final class ListEntitiesTest {
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          // Set no eventual consistency, that way queries return all results.
+          // https://cloud.google.com/appengine/docs/java/tools/localunittesting#Java_Writing_High_Replication_Datastore_tests
+          new LocalDatastoreServiceTestConfig()
+              .setDefaultHighRepJobPolicyUnappliedJobPercentage(0));
+
+  private DatastoreService datastore;
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void listEntities() throws Exception {
+
+    final Query q =
+        new Query("Blogpost").setFilter(new FilterPredicate("title", FilterOperator.NOT_EQUAL, ""));
+
+    int counter = 1;
+
+    // Create six entities, one without a title
+    Entity post1 = createEntity("post1", "Title1", "Author1", "Content1");
+    Entity post2 = createEntity("post2", "Title2", "Author2", "Content2");
+    Entity post3 = createEntity("post3", "Title3", "Author3", "Content3");
+    Entity post4 = createEntity("post4", "Title4", "Author4", "Content4");
+    Entity post5 = createEntity("post5", "Title5", "Author5", "Content5");
+    Entity post6 = createEntity("post6", "", "Author6", "Content6");
+
+    datastore.put(ImmutableList.<Entity>of(post1, post2, post3, post4, post5, post6));
+
+    PreparedQuery pq = datastore.prepare(q);
+    List<Entity> posts = pq.asList(FetchOptions.Builder.withDefaults());
+
+    assertThat(posts).named("query results").containsExactly(post1, post2, post3, post4, post5);
+
+    for (Entity result : posts) {
+
+      assertThat((String) result.getProperty("title"))
+          .named("result.title")
+          .isEqualTo("Title" + counter);
+      assertThat((String) result.getProperty("author"))
+          .named("result.author")
+          .isEqualTo("Author" + counter);
+      assertThat((String) result.getProperty("body"))
+          .named("result.body")
+          .isEqualTo("Content" + counter);
+      assertThat((Date) result.getProperty("timestamp")).named("result.timestamp").isNotNull();
+
+      counter++;
+    }
+  }
+
+  private Entity createEntity(String key, String title, String author, String body) {
+
+    Entity newsPost = new Entity("Blogpost", key);
+    newsPost.setProperty("title", title);
+    newsPost.setProperty("author", author);
+    newsPost.setProperty("body", body);
+    newsPost.setProperty("timestamp", new Date());
+
+    return newsPost;
+  }
+}

--- a/datastore/src/test/java/com/example/appengine/UpdateEntitiesTest.java
+++ b/datastore/src/test/java/com/example/appengine/UpdateEntitiesTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.appengine.datastore;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import java.util.Date;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link UpdateEntities}. */
+@RunWith(JUnit4.class)
+public final class UpdateEntitiesTest {
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          // Set no eventual consistency, that way queries return all results.
+          // https://cloud.google.com/appengine/docs/java/tools/localunittesting#Java_Writing_High_Replication_Datastore_tests
+          new LocalDatastoreServiceTestConfig()
+              .setDefaultHighRepJobPolicyUnappliedJobPercentage(0));
+
+  private DatastoreService datastore;
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void entityUpdate() throws Exception {
+    Entity newsPost = new Entity("Blogpost", "breakingnews");
+    newsPost.setProperty("title", "BREAKING NEWS!");
+    newsPost.setProperty("author", "News hound");
+    newsPost.setProperty("body", "Stop press! Sky is blue.");
+    newsPost.setProperty("timestamp", new Date().getTime());
+
+    datastore.put(newsPost);
+
+    // get the entry and update it leaving the author the same
+    Entity updateNewsPost = datastore.get(newsPost.getKey());
+    updateNewsPost.setProperty("title", "OLD NEWS!");
+    updateNewsPost.setProperty("body", "The sky is not blue.");
+    updateNewsPost.setProperty("timestamp", new Date());
+
+    datastore.put(updateNewsPost);
+
+    Entity got = datastore.get(updateNewsPost.getKey());
+    assertThat((String) got.getProperty("title")).named("got.title").isEqualTo("OLD NEWS!");
+    assertThat((String) got.getProperty("author")).named("got.author").isEqualTo("News hound");
+    assertThat((String) got.getProperty("body"))
+        .named("got.body")
+        .isEqualTo("The sky is not blue.");
+    assertThat((Date) got.getProperty("timestamp")).named("got.timestamp").isNotNull();
+  }
+}

--- a/datastore/src/test/java/com/example/appengine/WriteEntitiesTest.java
+++ b/datastore/src/test/java/com/example/appengine/WriteEntitiesTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine.datatstore;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import java.util.Date;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class WriteEntitiesTest {
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          // Set no eventual consistency, that way queries return all results.
+          // https://cloud.google.com/appengine/docs/java/tools/localunittesting#Java_Writing_High_Replication_Datastore_tests
+          new LocalDatastoreServiceTestConfig()
+              .setDefaultHighRepJobPolicyUnappliedJobPercentage(0));
+
+  private DatastoreService datastore;
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void entityWrite() throws Exception {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+    Entity newsPost = new Entity("Blogpost", "breakingnews");
+    newsPost.setProperty("title", "BREAKING NEWS!");
+    newsPost.setProperty("author", "News hound");
+    newsPost.setProperty("body", "Stop press! Sky is blue.");
+    newsPost.setProperty("timestamp", new Date());
+
+    datastore.put(newsPost);
+
+    Entity got = datastore.get(newsPost.getKey());
+    assertThat((String) got.getProperty("title")).named("got.title").isEqualTo("BREAKING NEWS!");
+    assertThat((String) got.getProperty("author")).named("got.author").isEqualTo("News hound");
+    assertThat((String) got.getProperty("body"))
+        .named("got.body")
+        .isEqualTo("Stop press! Sky is blue.");
+    assertThat((Date) got.getProperty("timestamp")).named("got.timestamp").isNotNull();
+  }
+}


### PR DESCRIPTION
Part of a new Getting Started experience for GAE Standard Java 8. This sample shows how to setup a simple J8 app - a blog - using Cloud Datastore as the storage backend.

Notes:
It is intended to be a standalone folder, hence the pom.xml does not have a parent.
Region tags for documentation to be added later.